### PR TITLE
Add note for "Honda" instead of "Ford" typo

### DIFF
--- a/300_Aggregations/30_histogram.asciidoc
+++ b/300_Aggregations/30_histogram.asciidoc
@@ -101,6 +101,7 @@ histogram keys correspond to the lower boundary of the interval.  The key `0`
 means `0-20,000`, the key `20000` means `20,000-40,000`, and so forth.
 
 Graphically, you could represent the preceding data in the histogram shown in <<barcharts-histo1>>:
+(Note: Honda should actually be "Ford" in the histogram if you are following the data)
 
 [[barcharts-histo1]]
 .Histogram of top makes per price range

--- a/310_Geopoints/32_Bounding_box.asciidoc
+++ b/310_Geopoints/32_Bounding_box.asciidoc
@@ -17,7 +17,7 @@ GET /attractions/restaurant/_search
         "geo_bounding_box": {
           "location": { <1>
             "top_left": {
-              "lat":  40,8,
+              "lat":  40.8,
               "lon": -74.0
             },
             "bottom_right": {
@@ -80,7 +80,7 @@ GET /attractions/restaurant/_search
           "type":    "indexed", <1>
           "location": {
             "top_left": {
-              "lat":  40,8,
+              "lat":  40.8,
               "lon": -74.0
             },
             "bottom_right": {


### PR DESCRIPTION
The graphical image of the histogram has been mislabeled where it says "Honda" instead of "Ford".  This typo makes it confusing since the data right above it clearly shows it should be "Ford"