### PR TITLE
Fixed 'date format reference documentation' link.

### DIFF
--- a/080_Structured_Search/25_ranges.asciidoc
+++ b/080_Structured_Search/25_ranges.asciidoc
@@ -117,7 +117,7 @@ math expression:
 
 Date math is _calendar aware_, so it knows the number of days in each month,
 days in a year, and so forth.  More details about working with dates can be found in
-the http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/_ranges.html#_ranges_on_dates[date format reference documentation].
+the http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-date-format.html[date format reference documentation].
 
 ==== Ranges on Strings
 


### PR DESCRIPTION
Seems like there was an invalid href in the 'date format reference documentation' link.