### PR TITLE
Fix link to scripting module in reference documentation.

### DIFF
--- a/030_Data/45_Partial_update.asciidoc
+++ b/030_Data/45_Partial_update.asciidoc
@@ -86,7 +86,7 @@ runs in a _sandbox_ to prevent malicious users from breaking out of
 Elasticsearch and attacking the server.
 
 You can read more about scripting in the
-http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/partial-updates.html#_using_scripts_to_make_partial_updates[scripting reference documentation].
+http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-scripting.html[scripting reference documentation].
 
 ****
 

--- a/110_Multi_Field_Search/20_Tuning_best_field_queries.asciidoc
+++ b/110_Multi_Field_Search/20_Tuning_best_field_queries.asciidoc
@@ -1,6 +1,6 @@
 === Tuning Best Fields Queries
 
-What would happen if the use((("multi-field search", "best fields queries", "tuning")))((("best fields queries", "tuning")))r had searched instead for ``quick pets''?  Both
+What would happen if the user((("multi-field search", "best fields queries", "tuning")))((("best fields queries", "tuning"))) had searched instead for ``quick pets''?  Both
 documents contain the word `quick`, but only document 2 contains the word
 `pets`. Neither document contains _both words_ in the _same field_.
 

--- a/310_Geopoints/32_Bounding_box.asciidoc
+++ b/310_Geopoints/32_Bounding_box.asciidoc
@@ -17,7 +17,7 @@ GET /attractions/restaurant/_search
         "geo_bounding_box": {
           "location": { <1>
             "top_left": {
-              "lat":  40,8,
+              "lat":  40.8,
               "lon": -74.0
             },
             "bottom_right": {
@@ -80,7 +80,7 @@ GET /attractions/restaurant/_search
           "type":    "indexed", <1>
           "location": {
             "top_left": {
-              "lat":  40,8,
+              "lat":  40.8,
               "lon": -74.0
             },
             "bottom_right": {

--- a/510_Deployment/50_heap.asciidoc
+++ b/510_Deployment/50_heap.asciidoc
@@ -93,11 +93,11 @@ of RAM.
 
 First, we would recommend to avoid such large machines (see <<hardware>>).
 
-But if you already have the machines, you have to practical options:
+But if you already have the machines, you have two practical options:
 
 1. Are you doing most full-text search?  Consider giving 32gb to Elasticsearch
 and just let Lucene use the rest of memory via the OS file system cache.  All that
-memory will cache segments and lead to blisteringly fast full-text search
+memory will cache segments and lead to blisteringly fast full-text search.
 
 2. Are you doing a lot of sorting/aggregations?  You'll likely want that memory
 in the heap then.  Instead of one node with 32gb+ of RAM, consider running two or
@@ -107,7 +107,7 @@ used for heaps, and 64 will be leftover for Lucene.
 +
 If you choose this option, set `cluster.routing.allocation.same_shard.host: true`
 in your config.  This will prevent a primary and a replica shard from co-locating
-to the same physical machine (since this would remove the benefits of replica HA)
+to the same physical machine (since this would remove the benefits of replica HA).
 ****
 
 ==== Swapping is the death of performance

--- a/520_Post_Deployment/40_rolling_restart.asciidoc
+++ b/520_Post_Deployment/40_rolling_restart.asciidoc
@@ -24,7 +24,7 @@ The procedure is as follows:
 help speed up recovery time
 
 2. Disable shard allocation.  This prevents Elasticsearch from re-balancing
-missing shards until you tell it otherwise.  If you know the maintenance will be
+missing shards until you tell it otherwise.  If you know the maintenance window will be
 short, this is a good idea.  You can disable allocation with:
 +
 [source,js]
@@ -47,8 +47,7 @@ POST /_cluster/nodes/_local/_shutdown
 
 4. Perform maintenance/upgrade
 5. Restart node, confirm that it joins the cluster
-6. Repeat 3-5 for the rest of your nodes
-7. Re-enable shard allocation using:
+6. Re-enable shard allocation using:
 +
 [source,js]
 ----
@@ -60,7 +59,10 @@ PUT /_cluster/settings
 }
 ----
 +
-Shard re-balancing may take some time.  At this point you are safe to resume
-indexing (if you had previously stopped), but waiting until the cluster is fully
-balanced before resuming indexing will help speed up the process
+Shard re-balancing may take some time. Wait until the cluster has _green_ status.
+
+7. Repeat 2-6 for the rest of your nodes
+8. At this point you are safe to resume indexing (if you had previously stopped),
+but waiting until the cluster is fully balanced before resuming indexing will help
+to speed up the process.
 


### PR DESCRIPTION
The original link seems to be erroneous, I think a link to modules-scripting reference would be better than a link to the same page.